### PR TITLE
Use `eventstored` as entrypoint to fix signaling

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ echo "NOTE:"
 echo "THIS CONTAINER IS FOR DEVELOPMENT PURPOSES ONLY AND SHOULD NOT BE USED IN PRODUCTION"
 echo ""
 
-eventstored
+exec eventstored


### PR DESCRIPTION
When using a bash shell as the main entrypoint, signals (SIGINT etc) will not
be propagated to sub processes, hence delaying shutdowns and restarts.
(Because Docker has a timeout before killing the container harder.)

As I didn't see the point of `entrypoint.sh`, I just removed it, but if it is
still needed, you should consider using something like dumb-init[0] to make
sure signals are sent to `eventstored`.

[0] https://github.com/Yelp/dumb-init
