### PR TITLE
Give the user the ability to specify the Event Store version to install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:14.04.3
 MAINTAINER Event Store LLP <ops@geteventstore.com>
 
+ENV ES_VERSION=3.7.0
+
 RUN apt-get update && apt-get install curl -y &&\
     curl -s https://packagecloud.io/install/repositories/EventStore/EventStore-OSS/script.deb.sh | bash &&\
-    apt-get install eventstore-oss -y &&\
+    apt-get install eventstore-oss=$ES_VERSION -y &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:14.04.3
 MAINTAINER Event Store LLP <ops@geteventstore.com>
 
+ENV ES_VERSION=3.7.0
+
 RUN apt-get update && apt-get install curl -y &&\
     curl -s https://packagecloud.io/install/repositories/EventStore/EventStore-OSS/script.deb.sh | bash &&\
-    apt-get install eventstore-oss -y &&\
+    apt-get install eventstore-oss=$ES_VERSION -y &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Fixes the issue encountered when merging this particular PR https://github.com/EventStore/eventstore-docker/pull/12
