### PR TITLE
Required changes for the image by Official-Images reviews

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
 FROM ubuntu:16.04
-MAINTAINER Event Store LLP <ops@geteventstore.com>
 
-ENV ES_VERSION=5.0.0-1 \
-    DEBIAN_FRONTEND=noninteractive \
+ENV ES_VERSION=5.0.0-1 \    
     EVENTSTORE_CLUSTER_GOSSIP_PORT=2112
 
 RUN apt-get update \
     && apt-get install tzdata curl iproute2 -y \
-    && curl -s https://packagecloud.io/install/repositories/EventStore/EventStore-OSS/script.deb.sh | bash \
-    && apt-get install eventstore-oss=$ES_VERSION -y \
-    && apt-get autoremove \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && curl -fSL -s https://packagecloud.io/install/repositories/EventStore/EventStore-OSS/script.deb.sh | bash \
+    && apt-get install eventstore-oss=$ES_VERSION -y      
 
 EXPOSE 1112 2112 1113 2113
 
@@ -19,7 +14,5 @@ VOLUME /var/lib/eventstore
 
 COPY eventstore.conf /etc/eventstore/
 COPY entrypoint.sh /
-
-HEALTHCHECK --timeout=2s CMD curl -sf http://localhost:2113/stats || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR is required to fix the Event Store image and pass the checks to be accepted as Official Docker Image.

The following [changes are required](https://github.com/docker-library/official-images/pull/5327) by the reviewers of the PR:

- HEALTHCHECKs are discouraged / forbidden in official images: https://github.com/docker-library/faq#healthcheck
- MAINTAINER is deprecated for Docker itself: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
- ENV DEBIAN_FRONTEND=noninteractive is a nono: moby/moby#4032 (comment)
- The script.deb.sh file is not being validated before being executed: https://github.com/docker-library/official-images#image-build
- The fSL flags are missing from the curl invocation
- curl should probably be removed (or is it required in the final image?)
- Your entrypoint does not allow to execute bash: https://github.com/docker-library/official-images#consistency
- [other required changes](https://github.com/docker-library/official-images/pull/5327#discussion_r262296933)

This Close #60 